### PR TITLE
Fixed the view

### DIFF
--- a/app/views/rails_admin/main/_tag_list.html.haml
+++ b/app/views/rails_admin/main/_tag_list.html.haml
@@ -1,2 +1,1 @@
-= field_wrapper_for(form, field) do
-  = form.send field.view_helper, field.name, field.html_attributes
+= form.send field.view_helper, field.name, field.html_attributes


### PR DESCRIPTION
Hi! Seems that _field_wrapper_for_ brokes _rails_admin_tag_list_field_ with the latest rails_admin. I've searched rails_admin sources to see the proper usage of this helper, but looks like it is not used at all - it's only decalred in _form_builder.rb_
