### PR TITLE
Suggestion links should toggle tags

### DIFF
--- a/app/views/rails_admin/main/_tag_list_with_suggestions.html.haml
+++ b/app/views/rails_admin/main/_tag_list_with_suggestions.html.haml
@@ -7,17 +7,21 @@
   jQuery(function(){
     var input_id = '#{form.dom_id(field)}'
     $('.tag_suggestion[data-input-id=' + input_id + ']').click(function(event){
-      var tag_list, new_value;
+      var tag_list, current_values, new_values, tag;
       tag_list = $(this).siblings('input#' + input_id);
+      // Get the current values by splitting on a comma and stripping whitespace.
+      current_values = jQuery.map(tag_list.val().split(','), function(val){ return jQuery.trim(val) });
+      tag = $(this).text();
+      // Remove the current tag, if present.
+      new_values = jQuery.grep(current_values, function(n) {
+        return jQuery.trim(n) != tag
+      });
+      // Add the current tag, unless we've altered the values already.
+      if (new_values.length == current_values.length) {
+        new_values[new_values.length] = tag
+      }
+      tag_list.val(new_values.join(', '));
 
-      if (!tag_list.val().match(/\S/)) {
-        new_value = this.innerHTML;
-      } else {
-        new_value = [tag_list.val(), this.innerHTML].join(', ');
-      };
-      tag_list.val(new_value);
-
-      event.preventDefault();
       return false;
     });
   });


### PR DESCRIPTION
Currently, tag suggestion links always add a tag. This commit allows them to toggle tags, instead.
