### PR TITLE
Support override of available tag list.

### DIFF
--- a/app/helpers/rails_admin_tag_list/suggestions_helper.rb
+++ b/app/helpers/rails_admin_tag_list/suggestions_helper.rb
@@ -1,6 +1,10 @@
 module RailsAdminTagList
   module SuggestionsHelper
     def tag_suggestions(field, options = {})
+      record = field.bindings[:object]
+      enum_method = '%s_enum' % field.name
+      return record.send(enum_method) if record.respond_to? enum_method
+
       defaults = {
         :order => { :count => :desc },
         :length => 5

--- a/app/views/rails_admin/main/_tag_list_with_suggestions.html.haml
+++ b/app/views/rails_admin/main/_tag_list_with_suggestions.html.haml
@@ -7,21 +7,17 @@
   jQuery(function(){
     var input_id = '#{form.dom_id(field)}'
     $('.tag_suggestion[data-input-id=' + input_id + ']').click(function(event){
-      var tag_list, current_values, new_values, tag;
+      var tag_list, new_value;
       tag_list = $(this).siblings('input#' + input_id);
-      // Get the current values by splitting on a comma and stripping whitespace.
-      current_values = jQuery.map(tag_list.val().split(','), function(val){ return jQuery.trim(val) });
-      tag = $(this).text();
-      // Remove the current tag, if present.
-      new_values = jQuery.grep(current_values, function(n) {
-        return jQuery.trim(n) != tag
-      });
-      // Add the current tag, unless we've altered the values already.
-      if (new_values.length == current_values.length) {
-        new_values[new_values.length] = tag
-      }
-      tag_list.val(new_values.join(', '));
 
+      if (!tag_list.val().match(/\S/)) {
+        new_value = this.innerHTML;
+      } else {
+        new_value = [tag_list.val(), this.innerHTML].join(', ');
+      };
+      tag_list.val(new_value);
+
+      event.preventDefault();
       return false;
     });
   });

--- a/app/views/rails_admin/main/_tag_list_with_suggestions.html.haml
+++ b/app/views/rails_admin/main/_tag_list_with_suggestions.html.haml
@@ -7,17 +7,21 @@
   jQuery(function(){
     var input_id = '#{form.dom_id(field)}'
     $('.tag_suggestion[data-input-id=' + input_id + ']').click(function(event){
-      var tag_list, new_value;
+      var tag_list, current_values, new_values, tag;
       tag_list = $(this).siblings('input#' + input_id);
+      // Get the current values by splitting on a comma and stripping whitespace.
+      current_values = jQuery.map(tag_list.val().split(','), function(val){ return jQuery.trim(val) });
+      tag = $(this).text();
+      // Remove the current tag, if present.
+      new_values = jQuery.grep(current_values, function(n) {
+        return jQuery.trim(n) != tag
+      });
+      // Add the current tag, unless we've altered the values already.
+      if (new_values.length == current_values.length) {
+        new_values[new_values.length] = tag
+      }
+      tag_list.val(new_values.join(', '));
 
-      if (!tag_list.val().match(/\S/)) {
-        new_value = this.innerHTML;
-      } else {
-        new_value = [tag_list.val(), this.innerHTML].join(', ');
-      };
-      tag_list.val(new_value);
-
-      event.preventDefault();
       return false;
     });
   });


### PR DESCRIPTION
This allows you to use the rails_admin convention of defining a field_name_enum method on your model to provide an explicit list of allowable options for the field.

For example, you might want to restrict tags for your Issue model to "pending", "closed", and "active". The tags field becomes something like another interface for a multiple-select enum.