### PR TITLE
fixing field value on record edit

### DIFF
--- a/lib/rails_admin_tag_list.rb
+++ b/lib/rails_admin_tag_list.rb
@@ -12,6 +12,10 @@ module RailsAdmin
       module Types
         class TagList < RailsAdmin::Config::Fields::Base
           RailsAdmin::Config::Fields::Types::register(self)
+          register_instance_option(:form_value) do
+            value.join(', ')
+          end
+          
           register_instance_option(:formatted_value) do
             value.join(', ')
           end


### PR DESCRIPTION
When a record need be edited, the tag_list field was completed with values without comma separation, making the record lose all tags.

This pull request fix it.
